### PR TITLE
AssemblyComponent OpenAPI 3 request body support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /package-lock.json
 /.nyc_output
+.idea/

--- a/spec/AssemblyPetStoreV2.js
+++ b/spec/AssemblyPetStoreV2.js
@@ -102,9 +102,7 @@ describe('With Assembly components for PetStore OpenAPI v2', () => {
       it('should make a HTTP POST', (done) => {
         const mock = nock('https://petstore.swagger.io')
           .post('/v2/pet', (body) => {
-            if (body.name !== 'Musti') {
-              return false;
-            }
+            chai.expect(body.name).to.equal('Musti');
             return true;
           })
           .reply(200);

--- a/spec/AssemblyPetStoreV3.js
+++ b/spec/AssemblyPetStoreV3.js
@@ -1,0 +1,69 @@
+const nock = require('nock');
+const { registerSwaggerComponents } = require('../src/index');
+
+describe('With Assembly components for PetStore OpenAPI v3', () => {
+  const loader = new noflo.ComponentLoader(process.cwd());
+  const def = {
+    url: 'https://petstore3.swagger.io/api/v3/openapi.json',
+    assembly: true,
+    icon: 'cart-arrow-down',
+  };
+  before(() => loader.listComponents());
+  describe('registering Swagger assembly components', () => {
+    before(() => registerSwaggerComponents(loader, 'petstore', def));
+    it('should have registered components', () => {
+      chai.expect(Object.keys(loader.components).length).to.be.above(1);
+    });
+  });
+  describe('AddPet component', () => {
+    let c;
+    it('should be possible to load', () => loader
+      .load('petstore/AddPet')
+      .then((instance) => {
+        c = instance;
+      }));
+    it('should have the expected ports', () => {
+      chai.expect(c.inPorts.in).to.be.an('object');
+      chai.expect(c.outPorts.out).to.be.an('object');
+    });
+    describe('calling the API', () => {
+      const ins = noflo.internalSocket.createSocket();
+      const out = noflo.internalSocket.createSocket();
+      before(() => {
+        c.inPorts.in.attach(ins);
+        c.outPorts.out.attach(out);
+      });
+      after(() => {
+        c.inPorts.in.detach(ins);
+        c.outPorts.out.detach(out);
+        nock.cleanAll();
+      });
+      it('should make a HTTP POST', (done) => {
+        const mock = nock('https://petstore3.swagger.io')
+          .post('/api/v3/pet', (body) => {
+            chai.expect(body.name).to.equal('Musti');
+            return true;
+          })
+          .reply(200);
+
+        out.on('data', (data) => {
+          chai.expect(mock.isDone());
+          chai.expect(data.response.status).to.equal(200);
+          done();
+        });
+        ins.send({
+          parameters: {
+            body: {
+              name: 'Musti',
+              category: {
+                id: 1,
+                name: 'dogs',
+              },
+              status: 'available',
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/AssemblyComponent.js
+++ b/src/AssemblyComponent.js
@@ -13,16 +13,23 @@ class AssemblyComponent extends Component {
   }
 
   relay(msg, output) {
-    this.apiMethod(msg.parameters)
-      .then((response) => {
-        output.sendDone({
-          ...msg,
-          parameters: undefined,
-          response,
-        });
-      }, (error) => {
-        output.sendDone(fail(msg, error));
+    this.apiMethod(
+      msg.parameters,
+      // With OpenAPI 3, a request body is no longer read from parameters.body but from the second
+      // parameter (value of key requestBody). That parameter is used with default value {} for
+      // OpenAPI 2.
+      // See: https://github.com/swagger-api/swagger-js/blob/master/docs/usage/tags-interface.md#openapi-v3x
+      msg.parameters !== undefined && Object.keys(msg.parameters).find((key) => key === 'body')
+        ? { requestBody: msg.parameters.body } : {},
+    ).then((response) => {
+      output.sendDone({
+        ...msg,
+        parameters: undefined,
+        response,
       });
+    }, (error) => {
+      output.sendDone(fail(msg, error));
+    });
   }
 }
 


### PR DESCRIPTION
`swagger-client` handles request bodies in OpenAPI 2 and 3 differently. The proposed change aims to transparently support both.

See [swagger-client documentation](https://github.com/swagger-api/swagger-js/blob/master/docs/usage/tags-interface.md#openapi-v3x) for details.

You can temporarily revert [this change](https://github.com/noflo/noflo-swagger-client/pull/59/files#diff-71bfa23e085f6b257d49c5a7610cfeeac606d7ad6a14516a88224dd4d4fdea6aR18-R23) and [this assertion](https://github.com/noflo/noflo-swagger-client/pull/59/files#diff-c8883b0bdc5415b22c29b7c8fdecd916bda40b690c95fe5df68c4943908ea60eR44) will fail because body is undefined.